### PR TITLE
Fixed crash when looking for non-existent kubeconfig

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -70,7 +70,7 @@ var startCmd = &cobra.Command{
 		}
 
 		if !registry.OK && !cluster.OK {
-			ezk.FmtYellow("Hint:\n")
+			ezk.FmtGreen("Hint:\n")
 			createCmd.Help()
 		}
 


### PR DESCRIPTION
When installing easykube for the first time, we would end up in a chicken-and-egg situation. The program initialised too early, expecting a kubeconfig to be present, and would not allow the cluster to be created. Fixed.

If easykube cannot find it's kubeconfig, a warning is printed, and will go away once the cluster is created. 